### PR TITLE
MTDSA-26328 : Remove scopes from APIDefinition

### DIFF
--- a/app/definition/ApiDefinition.scala
+++ b/app/definition/ApiDefinition.scala
@@ -18,7 +18,6 @@ package definition
 
 import play.api.libs.json.{Format, Json, OFormat}
 import routing.Version
-import uk.gov.hmrc.auth.core.ConfidenceLevel
 import utils.enums.Enums
 
 case class Parameter(name: String, required: Boolean = false)
@@ -77,13 +76,7 @@ object APIDefinition {
   implicit val formatAPIDefinition: OFormat[APIDefinition] = Json.format[APIDefinition]
 }
 
-case class Scope(key: String, name: String, description: String, confidenceLevel: ConfidenceLevel)
-
-object Scope {
-  implicit val formatScope: OFormat[Scope] = Json.format[Scope]
-}
-
-case class Definition(scopes: Seq[Scope], api: APIDefinition)
+case class Definition(api: APIDefinition)
 
 object Definition {
   implicit val formatDefinition: OFormat[Definition] = Json.format[Definition]

--- a/app/definition/ApiDefinitionFactory.scala
+++ b/app/definition/ApiDefinitionFactory.scala
@@ -26,8 +26,6 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class ApiDefinitionFactory @Inject() (appConfig: AppConfig) {
 
-  private val readScope      = "read:self-assessment"
-  private val writeScope     = "write:self-assessment"
   private val logger: Logger = Logger(this.getClass)
 
   lazy val confidenceLevel: ConfidenceLevel = {
@@ -38,20 +36,6 @@ class ApiDefinitionFactory @Inject() (appConfig: AppConfig) {
 
   lazy val definition: Definition =
     Definition(
-      scopes = List(
-        Scope(
-          key = readScope,
-          name = "View your Self Assessment information",
-          description = "Allow read access to self assessment data",
-          confidenceLevel = confidenceLevel
-        ),
-        Scope(
-          key = writeScope,
-          name = "Change your Self Assessment information",
-          description = "Allow write access to self assessment data",
-          confidenceLevel = confidenceLevel
-        )
-      ),
       api = APIDefinition(
         name = "Individuals Other Income (MTD)",
         description = "An API for providing individual other income data",

--- a/it/config/DocumentationControllerISpec.scala
+++ b/it/config/DocumentationControllerISpec.scala
@@ -28,26 +28,9 @@ import scala.util.Try
 
 class DocumentationControllerISpec extends IntegrationBaseSpec {
 
-  private val config          = app.injector.instanceOf[AppConfig]
-  private val confidenceLevel = config.confidenceLevelConfig.confidenceLevel
-
   private val apiDefinitionJson = Json.parse(
     s"""
     |{
-    |   "scopes":[
-    |      {
-    |         "key":"read:self-assessment",
-    |         "name":"View your Self Assessment information",
-    |         "description":"Allow read access to self assessment data",
-    |         "confidenceLevel": $confidenceLevel
-    |      },
-    |      {
-    |         "key":"write:self-assessment",
-    |         "name":"Change your Self Assessment information",
-    |         "description":"Allow write access to self assessment data",
-    |         "confidenceLevel": $confidenceLevel
-    |      }
-    |   ],
     |   "api":{
     |      "name":"Individuals Other Income (MTD)",
     |      "description":"An API for providing individual other income data",

--- a/test/definition/APIStatusSpec.scala
+++ b/test/definition/APIStatusSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package definition
+
+import definition.APIStatus.{ALPHA, BETA, DEPRECATED, RETIRED, STABLE}
+import support.UnitSpec
+import utils.enums.EnumJsonSpecSupport
+
+class APIStatusSpec extends UnitSpec with EnumJsonSpecSupport {
+
+  testRoundTrip[APIStatus](
+    ("ALPHA", ALPHA),
+    ("BETA", BETA),
+    ("STABLE", STABLE),
+    ("DEPRECATED", DEPRECATED),
+    ("RETIRED", RETIRED)
+  )
+
+}

--- a/test/definition/ApiDefinitionFactorySpec.scala
+++ b/test/definition/ApiDefinitionFactorySpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package definition
+
+import config.ConfidenceLevelConfig
+import definition.APIStatus.{ALPHA, BETA}
+import mocks.MockAppConfig
+import routing.Version1
+import support.UnitSpec
+import uk.gov.hmrc.auth.core.ConfidenceLevel
+
+class ApiDefinitionFactorySpec extends UnitSpec with MockAppConfig {
+
+  private val confidenceLevel: ConfidenceLevel = ConfidenceLevel.L200
+
+  class Test extends MockAppConfig {
+    val apiDefinitionFactory = new ApiDefinitionFactory(mockAppConfig)
+    MockedAppConfig.apiGatewayContext returns "individuals/person"
+  }
+
+  "definition" when {
+    "called" should {
+      "return a valid Definition case class when confidence level 200 checking is enforced" in {
+        testDefinitionWithConfidence(ConfidenceLevelConfig(confidenceLevel = confidenceLevel, definitionEnabled = true, authValidationEnabled = true))
+      }
+
+      "return a valid Definition case class when confidence level checking 50 is enforced" in {
+        testDefinitionWithConfidence(
+          ConfidenceLevelConfig(confidenceLevel = confidenceLevel, definitionEnabled = false, authValidationEnabled = false))
+      }
+
+      def testDefinitionWithConfidence(confidenceLevelConfig: ConfidenceLevelConfig): Unit = new Test {
+        MockedAppConfig.apiStatus(Version1) returns "BETA"
+        MockedAppConfig.endpointsEnabled(Version1) returns true
+        MockedAppConfig.confidenceLevelCheckEnabled.returns(confidenceLevelConfig).anyNumberOfTimes()
+
+        apiDefinitionFactory.definition shouldBe
+          Definition(
+            api = APIDefinition(
+              name = "Individuals Other Income (MTD)",
+              description = "An API for providing individual other income data",
+              context = "individuals/person",
+              categories = List("INCOME_TAX_MTD"),
+              versions = List(
+                APIVersion(
+                  Version1,
+                  status = BETA,
+                  endpointsEnabled = true
+                )
+              ),
+              requiresTrust = None
+            )
+          )
+      }
+    }
+  }
+
+  "confidenceLevel" when {
+    List(
+      (true, ConfidenceLevel.L250, ConfidenceLevel.L250),
+      (true, ConfidenceLevel.L200, ConfidenceLevel.L200),
+      (false, ConfidenceLevel.L200, ConfidenceLevel.L50)
+    ).foreach { case (definitionEnabled, configCL, expectedDefinitionCL) =>
+      s"confidence-level-check.definition.enabled is $definitionEnabled and confidence-level = $configCL" should {
+        s"return confidence level $expectedDefinitionCL" in new Test {
+          MockedAppConfig.confidenceLevelCheckEnabled returns ConfidenceLevelConfig(
+            confidenceLevel = configCL,
+            definitionEnabled = definitionEnabled,
+            authValidationEnabled = true)
+          apiDefinitionFactory.confidenceLevel shouldBe expectedDefinitionCL
+        }
+      }
+    }
+  }
+
+  "buildAPIStatus" when {
+    "the 'apiStatus' parameter is present and valid" should {
+      "return the correct status" in new Test {
+        MockedAppConfig.apiStatus(Version1) returns "BETA"
+        apiDefinitionFactory.buildAPIStatus(Version1) shouldBe BETA
+      }
+    }
+
+    "the 'apiStatus' parameter is present and invalid" should {
+      "default to alpha" in new Test {
+        MockedAppConfig.apiStatus(Version1) returns "ALPHA"
+        apiDefinitionFactory.buildAPIStatus(Version1) shouldBe ALPHA
+      }
+    }
+  }
+
+}

--- a/test/definition/ApiDefinitionSpec.scala
+++ b/test/definition/ApiDefinitionSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package definition
+
+import routing.Version1
+import support.UnitSpec
+
+class ApiDefinitionSpec extends UnitSpec {
+
+  private val apiVersion: APIVersion       = APIVersion(Version1, APIStatus.ALPHA, endpointsEnabled = true)
+  private val apiDefinition: APIDefinition = APIDefinition("b", "c", "d", Seq("e"), Seq(apiVersion), Some(false))
+
+  "APIDefinition" when {
+    "the 'name' parameter is empty" should {
+      "throw an 'IllegalArgumentException'" in {
+        assertThrows[IllegalArgumentException](
+          apiDefinition.copy(name = "")
+        )
+      }
+    }
+  }
+
+  "the 'description' parameter is empty" should {
+    "throw an 'IllegalArgumentException'" in {
+      assertThrows[IllegalArgumentException](
+        apiDefinition.copy(description = "")
+      )
+    }
+  }
+
+  "the 'context' parameter is empty" should {
+    "throw an 'IllegalArgumentException'" in {
+      assertThrows[IllegalArgumentException](
+        apiDefinition.copy(context = "")
+      )
+    }
+  }
+
+  "the 'categories' parameter is empty" should {
+    "throw an 'IllegalArgumentException'" in {
+      assertThrows[IllegalArgumentException](
+        apiDefinition.copy(categories = Nil)
+      )
+    }
+  }
+
+  "the 'versions' parameter is empty" should {
+    "throw an 'IllegalArgumentException'" in {
+      assertThrows[IllegalArgumentException](
+        apiDefinition.copy(versions = List(apiVersion, apiVersion))
+      )
+    }
+  }
+
+  "the 'versions' parameter is not unique" should {
+    "throw an 'IllegalArgumentException'" in {
+      assertThrows[IllegalArgumentException](
+        apiDefinition.copy(versions = Nil)
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
MTDSA-26328 : Remove scopes from APIDefinition in individuals-other-income-api