### PR TITLE
POC to restrict frontend country code validation to permitted values only

### DIFF
--- a/app/shared/controllers/validators/resolvers/ResolveParsedCountryCode.scala
+++ b/app/shared/controllers/validators/resolvers/ResolveParsedCountryCode.scala
@@ -18,47 +18,266 @@ package shared.controllers.validators.resolvers
 
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
-import com.neovisionaries.i18n.CountryCode
-import shared.controllers.validators.resolvers.ResolveParsedCountryCode.permittedCustomCodes
 import shared.models.errors.{CountryCodeFormatError, MtdError, RuleCountryCodeError}
-
-case class ResolveParsedCountryCode(path: String) {
-
-  def apply(value: String): Validated[List[MtdError], String] = {
-    if (value.length != 3) {
-      Invalid(List(CountryCodeFormatError.withPath(path)))
-    } else if (permittedCustomCodes.contains(value)) {
-      Valid(value)
-    } else {
-      Option(CountryCode.getByAlpha3Code(value)) match {
-        case Some(_) => Valid(value)
-        case None    => Invalid(List(RuleCountryCodeError.withPath(path)))
-      }
-    }
-  }
-
-  def apply(maybeValue: Option[String]): Validated[List[MtdError], Option[String]] = {
-    maybeValue match {
-      case Some(value) => apply(value).map(Option(_))
-      case None        => Valid(None)
-    }
-  }
-
-}
 
 object ResolveParsedCountryCode {
 
-  private val permittedCustomCodes = Set("ZZZ")
+  private[resolvers] val permittedCodes = Set(
+    "AFG",
+    "ALB",
+    "DZA",
+    "ASM",
+    "AND",
+    "AGO",
+    "AIA",
+    "ATG",
+    "ARG",
+    "ARM",
+    "ABW",
+    "AUS",
+    "AUT",
+    "AZE",
+    "BHS",
+    "BHR",
+    "BGD",
+    "BRB",
+    "BLR",
+    "BEL",
+    "BLZ",
+    "BEN",
+    "BMU",
+    "BTN",
+    "BOL",
+    "BES",
+    "BIH",
+    "BWA",
+    "BRA",
+    "VGB",
+    "BRN",
+    "BGR",
+    "BFA",
+    "MMR",
+    "BDI",
+    "KHM",
+    "CMR",
+    "CAN",
+    "CPV",
+    "CYM",
+    "CAF",
+    "TCD",
+    "CHL",
+    "CHN",
+    "CXR",
+    "CCK",
+    "COL",
+    "COM",
+    "COG",
+    "COK",
+    "CRI",
+    "CIV",
+    "HRV",
+    "CUB",
+    "CUW",
+    "CYP",
+    "CZE",
+    "COD",
+    "DNK",
+    "DJI",
+    "DMA",
+    "DOM",
+    "ECU",
+    "EGY",
+    "SLV",
+    "GNQ",
+    "ERI",
+    "EST",
+    "ETH",
+    "FLK",
+    "FRO",
+    "FJI",
+    "FIN",
+    "FRA",
+    "GUF",
+    "PYF",
+    "GAB",
+    "GMB",
+    "GEO",
+    "DEU",
+    "GHA",
+    "GIB",
+    "GRC",
+    "GRL",
+    "GRD",
+    "GLP",
+    "GUM",
+    "GTM",
+    "GGY",
+    "GIN",
+    "GNB",
+    "GUY",
+    "HTI",
+    "HND",
+    "HKG",
+    "HUN",
+    "ISL",
+    "IND",
+    "IDN",
+    "IRN",
+    "IRQ",
+    "IRL",
+    "IMN",
+    "ISR",
+    "ITA",
+    "JAM",
+    "JPN",
+    "JEY",
+    "JOR",
+    "KAZ",
+    "KEN",
+    "KIR",
+    "XKX",
+    "KWT",
+    "KGZ",
+    "LAO",
+    "LVA",
+    "LBN",
+    "LSO",
+    "LBR",
+    "LBY",
+    "LIE",
+    "LTU",
+    "LUX",
+    "MAC",
+    "MKD",
+    "MDG",
+    "MWI",
+    "MYS",
+    "MDV",
+    "MLI",
+    "MLT",
+    "MHL",
+    "MTQ",
+    "MRT",
+    "MUS",
+    "MYT",
+    "MEX",
+    "FSM",
+    "MDA",
+    "MCO",
+    "MNG",
+    "MNE",
+    "MSR",
+    "MAR",
+    "MOZ",
+    "NAM",
+    "NRU",
+    "NPL",
+    "NLD",
+    "NCL",
+    "NZL",
+    "NIC",
+    "NER",
+    "NGA",
+    "NIU",
+    "NFK",
+    "PRK",
+    "MNP",
+    "NOR",
+    "OMN",
+    "PAK",
+    "PLW",
+    "PAN",
+    "PNG",
+    "PRY",
+    "PER",
+    "PHL",
+    "PCN",
+    "POL",
+    "PRT",
+    "PRI",
+    "QAT",
+    "REU",
+    "ROU",
+    "RUS",
+    "RWA",
+    "SHN",
+    "KNA",
+    "LCA",
+    "SPM",
+    "VCT",
+    "WSM",
+    "SMR",
+    "STP",
+    "SAU",
+    "SEN",
+    "SRB",
+    "SYC",
+    "SLE",
+    "SGP",
+    "SXM",
+    "SVK",
+    "SVN",
+    "SLB",
+    "SOM",
+    "ZAF",
+    "KOR",
+    "SSD",
+    "ESP",
+    "LKA",
+    "SDN",
+    "SUR",
+    "SJM",
+    "SWZ",
+    "SWE",
+    "CHE",
+    "SYR",
+    "TWN",
+    "TJK",
+    "TZA",
+    "THA",
+    "TLS",
+    "TGO",
+    "TKL",
+    "TON",
+    "TTO",
+    "TUN",
+    "TUR",
+    "TKM",
+    "TCA",
+    "TUV",
+    "UGA",
+    "UKR",
+    "ARE",
+    "USA",
+    "VIR",
+    "URY",
+    "UZB",
+    "VUT",
+    "VAT",
+    "VEN",
+    "VNM",
+    "WLF",
+    "YEM",
+    "ZMB",
+    "ZWE",
+    "ZZZ"
+  )
 
-  def apply(value: String, path: String): Validated[Seq[MtdError], String] = {
-    val resolver = ResolveParsedCountryCode(path)
-
-    resolver(value)
+  def apply(value: String, path: String): Validated[List[MtdError], String] = {
+    if (value.length != 3) {
+      Invalid(List(CountryCodeFormatError.withPath(path)))
+    } else if (permittedCodes.contains(value)) {
+      Valid(value)
+    } else {
+      Invalid(List(RuleCountryCodeError.withPath(path)))
+    }
   }
 
-  def apply(maybeValue: Option[String], path: String): Validated[Seq[MtdError], Option[String]] = {
-    val resolver = ResolveParsedCountryCode(path)
-    resolver(maybeValue)
+  def apply(maybeValue: Option[String], path: String): Validated[List[MtdError], Option[String]] = {
+    maybeValue match {
+      case Some(value) => apply(value, path).map(Option(_))
+      case None        => Valid(None)
+    }
   }
 
 }

--- a/app/shared/models/errors/CommonMtdErrors.scala
+++ b/app/shared/models/errors/CommonMtdErrors.scala
@@ -106,7 +106,7 @@ object RuleDateRangeInvalidError extends MtdError(code = "RULE_DATE_RANGE_INVALI
 object RuleEndBeforeStartDateError
     extends MtdError("RULE_END_DATE_BEFORE_START_DATE", "The supplied accounting period end date is before the start date", BAD_REQUEST)
 
-object RuleCountryCodeError extends MtdError("RULE_COUNTRY_CODE", "The country code is not a valid ISO 3166-1 alpha-3 country code", BAD_REQUEST)
+object RuleCountryCodeError extends MtdError("RULE_COUNTRY_CODE", "The country code is not a permitted ISO 3166-1 alpha-3 country code", BAD_REQUEST)
 
 //Stub Errors
 object RuleIncorrectGovTestScenarioError

--- a/it/test/v2/endpoints/CreateAmendOtherControllerISpec.scala
+++ b/it/test/v2/endpoints/CreateAmendOtherControllerISpec.scala
@@ -416,7 +416,7 @@ class CreateAmendOtherControllerISpec extends IntegrationBaseSpec {
             |        },
             |        {
             |            "code": "RULE_COUNTRY_CODE",
-            |            "message": "The country code is not a valid ISO 3166-1 alpha-3 country code",
+            |            "message": "The country code is not a permitted ISO 3166-1 alpha-3 country code",
             |            "paths": [
             |                "/allOtherIncomeReceivedWhilstAbroad/1/countryCode"
             |            ]

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,8 +7,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapPlayVersion,
     "org.typelevel"     %% "cats-core"                 % "2.13.0",
-    "com.github.jknack"  % "handlebars"                % "4.3.1",
-    "com.neovisionaries" % "nv-i18n"                   % "1.29"
+    "com.github.jknack"  % "handlebars"                % "4.3.1"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/resources/public/api/conf/2.0/common/errors.yaml
+++ b/resources/public/api/conf/2.0/common/errors.yaml
@@ -57,10 +57,10 @@ components:
         message: The provided Country code is invalid
         
     ruleCountryCode:
-      description: Not a valid ISO 3166-1 alpha-3 country code.
+      description: Not a permitted ISO 3166-1 alpha-3 country code.
       value:
         code: RULE_COUNTRY_CODE
-        message: The country code is not a valid ISO 3166-1 alpha-3 country code
+        message: The country code is not a permitted ISO 3166-1 alpha-3 country code
         
     formatDate:
       description: The supplied date format is not valid.

--- a/test/shared/controllers/validators/resolvers/ResolveParsedCountryCodeSpec.scala
+++ b/test/shared/controllers/validators/resolvers/ResolveParsedCountryCodeSpec.scala
@@ -22,60 +22,43 @@ import shared.utils.UnitSpec
 
 class ResolveParsedCountryCodeSpec extends UnitSpec {
 
+  private val permittedCountryCodes = ResolveParsedCountryCode.permittedCodes.toSeq.sorted
+
   "ResolveParsedCountryCode" must {
-      // @formatter:off
-    List("AFG", "ALB", "DZA", "ASM", "AND", "AGO", "AIA", "ATG", "ARG", "ARM", "ABW", "AUS", "AUT", "AZE", "BHS",
-        "BHR", "BGD", "BRB", "BLR", "BEL", "BLZ", "BEN", "BMU", "BTN", "BOL", "BES", "BIH", "BWA", "BRA", "VGB",
-        "BRN", "BGR", "BFA", "MMR", "BDI", "KHM", "CMR", "CAN", "CPV", "CYM", "CAF", "TCD", "CHL", "CHN", "CXR",
-        "CCK", "COL", "COM", "COG", "COK", "CRI", "CIV", "HRV", "CUB", "CUW", "CYP", "CZE", "COD", "DNK", "DJI",
-        "DMA", "DOM", "ECU", "EGY", "SLV", "GNQ", "ERI", "EST", "ETH", "FLK", "FRO", "FJI", "FIN", "FRA", "GUF",
-        "PYF", "GAB", "GMB", "GEO", "DEU", "GHA", "GIB", "GRC", "GRL", "GRD", "GLP", "GUM", "GTM", "GGY", "GIN",
-        "GNB", "GUY", "HTI", "HND", "HKG", "HUN", "ISL", "IND", "IDN", "IRN", "IRQ", "IRL", "IMN", "ISR", "ITA",
-        "JAM", "JPN", "JEY", "JOR", "KAZ", "KEN", "KIR", "XKX", "KWT", "KGZ", "LAO", "LVA", "LBN", "LSO", "LBR",
-        "LBY", "LIE", "LTU", "LUX", "MAC", "MKD", "MDG", "MWI", "MYS", "MDV", "MLI", "MLT", "MHL", "MTQ", "MRT",
-        "MUS", "MYT", "MEX", "FSM", "MDA", "MCO", "MNG", "MNE", "MSR", "MAR", "MOZ", "NAM", "NRU", "NPL", "NLD",
-        "NCL", "NZL", "NIC", "NER", "NGA", "NIU", "NFK", "PRK", "MNP", "NOR", "OMN", "PAK", "PLW", "PAN", "PNG",
-        "PRY", "PER", "PHL", "PCN", "POL", "PRT", "PRI", "QAT", "REU", "ROU", "RUS", "RWA", "SHN", "KNA", "LCA",
-        "SPM", "VCT", "WSM", "SMR", "STP", "SAU", "SEN", "SRB", "SYC", "SLE", "SGP", "SXM", "SVK", "SVN",
-        "SLB", "SOM", "ZAF", "KOR", "SSD", "ESP", "LKA", "SDN", "SUR", "SJM", "SWZ", "SWE", "CHE", "SYR", "TWN",
-        "TJK", "TZA", "THA", "TLS", "TGO", "TKL", "TON", "TTO", "TUN", "TUR", "TKM", "TCA", "TUV", "UGA", "UKR",
-        "ARE", "USA", "VIR", "URY", "UZB", "VUT", "VAT", "VEN", "VNM", "WLF", "YEM", "ZMB", "ZWE", "ZZZ")
-        .foreach {
-          code =>
-            s"return an empty list for valid country code $code" in {
-              val result = ResolveParsedCountryCode(code, path = "path")
-              result shouldBe Valid(code)
-            }
-        }
-      // @formatter:on
+    permittedCountryCodes.foreach { code =>
+      s"return valid for permitted country code $code" in {
+        val result = ResolveParsedCountryCode(code, "path")
+        result shouldBe Valid(code)
+      }
+    }
 
     "return valid for an empty optional country code" in {
-      val result = ResolveParsedCountryCode(None, path = "path")
+      val result = ResolveParsedCountryCode(None, "path")
       result shouldBe Valid(None)
     }
 
     "return valid for a valid optional country code" in {
-      val result = ResolveParsedCountryCode(Some("VEN"), path = "path")
+      val result = ResolveParsedCountryCode(Some("VEN"), "path")
       result shouldBe Valid(Some("VEN"))
     }
 
-    "return a CountryCodeFormatError for an invalid optional country code" in {
-      val result = ResolveParsedCountryCode(Some("notACountryCode"), path = "path")
+    "return a CountryCodeFormatError for a badly formatted country code" in {
+      val result = ResolveParsedCountryCode("FRANCE", "path")
       result shouldBe Invalid(List(CountryCodeFormatError.withPath("path")))
     }
 
-    "return a CountryCodeFormatError for an invalid country code" in {
-      val result = ResolveParsedCountryCode("notACountryCode", path = "path")
+    "return a CountryCodeFormatError for a badly formatted optional country code" in {
+      val result = ResolveParsedCountryCode(Some("FRANCE"), "path")
       result shouldBe Invalid(List(CountryCodeFormatError.withPath("path")))
     }
 
-    "return a CountryCodeFormatError for an invalid format country code" in {
-      val result = ResolveParsedCountryCode("FRANCE", path = "path")
-      result shouldBe Invalid(List(CountryCodeFormatError.withPath("path")))
+    "return a RuleCountryCodeError for an unpermitted ISO 3166-1 alpha-3 country code" in {
+      val result = ResolveParsedCountryCode("GBR", "path")
+      result shouldBe Invalid(List(RuleCountryCodeError.withPath("path")))
     }
 
-    "return a CountryCodeFormatError for an invalid rule country code" in {
-      val result = ResolveParsedCountryCode("FRE", path = "path")
+    "return a RuleCountryCodeError for an unpermitted ISO 3166-1 alpha-3 optional country code" in {
+      val result = ResolveParsedCountryCode(Some("GBR"), "path")
       result shouldBe Invalid(List(RuleCountryCodeError.withPath("path")))
     }
   }


### PR DESCRIPTION
Frontend country code validation relies on an [external library ](https://github.com/TakahikoKawasaki/nv-i18n) that allows a broader set of values than those permitted by the downstream specification, for example accepting codes such as `GBR`, which is not permitted for foreign property. This may result in users submitting country codes that are not accepted by backend validation, resulting in a schema validation error being returned.

The following ISO 3166-1 alpha-3 country codes from the library are not permitted by the specification and should be rejected: `ALA`, `ANT`, `ASC`, `ATA`, `ATF`, `BLM`, `BUR`, `BVT`, `CPT`, `DGA`, `ESH`, `FXX`, `GBR`, `HMD`, `IOT`, `MAF`, `NTZ`, `PSE`, `SCG`, `SGS`, `SUN`, `TAA`, `TMP`, `UMI`, `XXI`, `XXU`, `YUG`, `ZAR`. Reference: [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) 

The validation should be updated to enforce a strict allowlist of permitted alpha-3 country codes. Only values explicitly defined in the agreed set should be accepted, ensuring consistency between frontend and backend validation and preventing invalid submissions.